### PR TITLE
Crud admin ativ desativ

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,7 +19,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/management/', include('management.urls')),
+    path('api/admin/', include('management.urls')),
     path('api/analytics/', include('analytics.urls')),
     path('api/users/', include('users.urls')),
     path('api/core/', include('core.urls')),

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import DashboardLayout from "./pages/dashboard/DashboardLayout";
 import { Home } from "./pages/dashboard/Home";
-import Login from "./pages/Login/Login";
+import Login from "./pages/login/Login";
 import PrivateRoute from "./routes/PrivateRoute";
 import NewAttendance from "./pages/dashboard/NewAttendance";
 import Grafics from "./pages/dashboard/Grafics";

--- a/management/serializers.py
+++ b/management/serializers.py
@@ -1,0 +1,83 @@
+from rest_framework import serializers
+from core.models import Loja, Equipe
+from users.models import CustomUser
+from users.serializers import LojaSerializer, EquipeSerializer
+
+
+class UserAdminSerializer(serializers.ModelSerializer):
+    loja = serializers.PrimaryKeyRelatedField(
+        queryset=Loja.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+    equipe = serializers.PrimaryKeyRelatedField(
+        queryset=Equipe.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+    password = serializers.CharField(write_only=True, required=False)
+    pin = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
+    class Meta:
+        model = CustomUser
+        fields = [
+            'id',
+            'username',
+            'first_name',
+            'last_name',
+            'email',
+            'cargo',
+            'loja',
+            'equipe',
+            'is_active',
+            'pin',
+            'password',
+        ]
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['loja'] = LojaSerializer(instance.loja).data if instance.loja else None
+        data['equipe'] = EquipeSerializer(instance.equipe).data if instance.equipe else None
+        return data
+
+    def validate_pin(self, value):
+        if value in (None, ''):
+            return None
+        if len(value) != 4 or not value.isdigit():
+            raise serializers.ValidationError('PIN deve ter exatamente 4 digitos numericos.')
+        return value
+
+    def validate(self, attrs):
+        cargo = attrs.get('cargo')
+        if self.instance:
+            cargo = cargo or self.instance.cargo
+
+        pin = attrs.get('pin')
+        if self.instance and pin is None:
+            pin = self.instance.pin
+
+        if cargo == 'VENDEDOR' and not pin:
+            raise serializers.ValidationError({'pin': 'PIN e obrigatorio para vendedores.'})
+
+        if not self.instance and not attrs.get('password'):
+            raise serializers.ValidationError({'password': 'Senha e obrigatoria.'})
+
+        return attrs
+
+    def create(self, validated_data):
+        password = validated_data.pop('password')
+        user = CustomUser(**validated_data)
+        user.set_password(password)
+        user.save()
+        return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop('password', None)
+        if password:
+            instance.set_password(password)
+
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        instance.save()
+        return instance

--- a/management/tests.py
+++ b/management/tests.py
@@ -1,3 +1,184 @@
-from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase, APIClient
 
-# Create your tests here.
+from core.models import Loja, Equipe, Metrica, Relatorio
+from users.models import CustomUser
+
+
+class AdminUserCrudTests(APITestCase):
+	def setUp(self):
+		self.loja = Loja.objects.create(nome='Loja Centro', cidade='Sao Paulo')
+		self.equipe = Equipe.objects.create(nome='Equipe A', loja=self.loja)
+
+		self.admin = self._create_user(
+			email='admin@example.com',
+			username='admin',
+			first_name='Admin',
+			last_name='User',
+			cargo='ADMIN',
+			password='admin1234',
+		)
+		self.supervisor = self._create_user(
+			email='supervisor@example.com',
+			username='supervisor',
+			first_name='Super',
+			last_name='Visor',
+			cargo='SUPERVISOR',
+			password='super1234',
+			loja=self.loja,
+		)
+		self.vendedor = self._create_user(
+			email='vendedor@example.com',
+			username='vendedor',
+			first_name='Venda',
+			last_name='Dor',
+			cargo='VENDEDOR',
+			password='vend1234',
+			loja=self.loja,
+			equipe=self.equipe,
+			pin='1234',
+		)
+		self.dispositivo = self._create_user(
+			email='device@example.com',
+			username='device',
+			first_name='Device',
+			last_name='User',
+			cargo='DISPOSITIVO',
+			password='device1234',
+			loja=self.loja,
+		)
+
+		self.admin_token = Token.objects.create(user=self.admin)
+		self.supervisor_token = Token.objects.create(user=self.supervisor)
+		self.vendedor_token = Token.objects.create(user=self.vendedor)
+		self.dispositivo_token = Token.objects.create(user=self.dispositivo)
+
+		self.base_url = '/api/admin/usuarios/'
+
+	def _create_user(self, **kwargs):
+		password = kwargs.pop('password', 'default123')
+		user = CustomUser(**kwargs)
+		user.set_password(password)
+		user.save()
+		return user
+
+	def _auth_client(self, token):
+		client = APIClient()
+		client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+		return client
+
+	def test_admin_can_create_vendedor_with_pin(self):
+		client = self._auth_client(self.admin_token)
+		payload = {
+			'email': 'novo.vendedor@example.com',
+			'username': 'novo_vendedor',
+			'first_name': 'Novo',
+			'last_name': 'Vendedor',
+			'cargo': 'VENDEDOR',
+			'password': 'senha1234',
+			'pin': '5678',
+			'loja': self.loja.id,
+			'equipe': self.equipe.id,
+		}
+
+		response = client.post(self.base_url, payload, format='json')
+		self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+	def test_admin_cannot_create_vendedor_without_pin(self):
+		client = self._auth_client(self.admin_token)
+		payload = {
+			'email': 'sem.pin@example.com',
+			'username': 'sem_pin',
+			'first_name': 'Sem',
+			'last_name': 'Pin',
+			'cargo': 'VENDEDOR',
+			'password': 'senha1234',
+			'loja': self.loja.id,
+		}
+
+		response = client.post(self.base_url, payload, format='json')
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+		self.assertIn('pin', response.data)
+
+	def test_admin_can_create_non_vendedor_without_pin(self):
+		client = self._auth_client(self.admin_token)
+		payload = {
+			'email': 'novo.supervisor@example.com',
+			'username': 'novo_supervisor',
+			'first_name': 'Novo',
+			'last_name': 'Supervisor',
+			'cargo': 'SUPERVISOR',
+			'password': 'senha1234',
+			'loja': self.loja.id,
+		}
+
+		response = client.post(self.base_url, payload, format='json')
+		self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+	def test_admin_can_list_users_with_is_active(self):
+		client = self._auth_client(self.admin_token)
+		response = client.get(self.base_url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertIn('results', response.data)
+		self.assertTrue(any('is_active' in item for item in response.data['results']))
+
+	def test_admin_can_update_is_active_and_pin(self):
+		client = self._auth_client(self.admin_token)
+		url = f"{self.base_url}{self.vendedor.id}/"
+		response = client.patch(url, {'is_active': False}, format='json')
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.vendedor.refresh_from_db()
+		self.assertFalse(self.vendedor.is_active)
+
+		response = client.patch(url, {'pin': '9999'}, format='json')
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.vendedor.refresh_from_db()
+		self.assertEqual(self.vendedor.pin, '9999')
+
+		response = client.patch(url, {'is_active': True}, format='json')
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.vendedor.refresh_from_db()
+		self.assertTrue(self.vendedor.is_active)
+
+	def test_delete_not_allowed(self):
+		client = self._auth_client(self.admin_token)
+		url = f"{self.base_url}{self.vendedor.id}/"
+		response = client.delete(url)
+		self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+	def test_non_admin_cannot_access_endpoints(self):
+		for token in [self.supervisor_token, self.vendedor_token, self.dispositivo_token]:
+			client = self._auth_client(token)
+			response = client.get(self.base_url)
+			self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+	def test_inactive_user_cannot_login(self):
+		self.vendedor.is_active = False
+		self.vendedor.save()
+
+		response = self.client.post(
+			'/api/users/login/',
+			{'email': self.vendedor.email, 'password': 'vend1234'},
+			format='json',
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+	def test_atendimentos_remain_after_user_deactivation(self):
+		metrica = Metrica.objects.create(nome='Sem interesse', loja=self.loja)
+		relatorio = Relatorio.objects.create(
+			data_hora=timezone.now(),
+			venda_fechada=False,
+			metrica=metrica,
+			vendedor=self.vendedor,
+		)
+
+		client = self._auth_client(self.admin_token)
+		url = f"{self.base_url}{self.vendedor.id}/"
+		response = client.patch(url, {'is_active': False}, format='json')
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+		self.assertTrue(Relatorio.objects.filter(id=relatorio.id).exists())
+		relatorio.refresh_from_db()
+		self.assertEqual(relatorio.vendedor_id, self.vendedor.id)

--- a/management/tests.py
+++ b/management/tests.py
@@ -123,6 +123,7 @@ class AdminUserCrudTests(APITestCase):
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertIn('results', response.data)
 		self.assertTrue(any('is_active' in item for item in response.data['results']))
+		self.assertTrue(any('pin' in item for item in response.data['results']))
 
 	def test_admin_can_update_is_active_and_pin(self):
 		client = self._auth_client(self.admin_token)

--- a/management/urls.py
+++ b/management/urls.py
@@ -1,6 +1,10 @@
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import UserViewSet
 
-# Por enquanto deixamos vazio ou com uma rota de teste
+router = DefaultRouter()
+router.register(r'usuarios', UserViewSet, basename='admin-usuarios')
+
 urlpatterns = [
-    # path('funcionarios/', views.listar_funcionarios, name='listar_funcionarios'),
+    path('', include(router.urls)),
 ]

--- a/management/views.py
+++ b/management/views.py
@@ -1,3 +1,11 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from users.models import CustomUser
+from users.serializers import UserSerializer
+from users.permissions import IsAdmin
 
-# Create your views here.
+
+class UserViewSet(viewsets.ModelViewSet):
+	queryset = CustomUser.objects.all().order_by('id')
+	serializer_class = UserSerializer
+	permission_classes = [IsAdmin]
+	http_method_names = ['get', 'post', 'put', 'patch', 'head', 'options']

--- a/management/views.py
+++ b/management/views.py
@@ -1,11 +1,11 @@
 from rest_framework import viewsets
 from users.models import CustomUser
-from users.serializers import UserSerializer
+from .serializers import UserAdminSerializer
 from users.permissions import IsAdmin
 
 
 class UserViewSet(viewsets.ModelViewSet):
 	queryset = CustomUser.objects.all().order_by('id')
-	serializer_class = UserSerializer
+	serializer_class = UserAdminSerializer
 	permission_classes = [IsAdmin]
 	http_method_names = ['get', 'post', 'put', 'patch', 'head', 'options']

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -13,9 +13,79 @@ class EquipeSerializer(serializers.ModelSerializer):
         fields = ['id', 'nome']
 
 class UserSerializer(serializers.ModelSerializer):
-    loja = LojaSerializer(read_only=True)
-    equipe = EquipeSerializer(read_only=True)
+    loja = serializers.PrimaryKeyRelatedField(
+        queryset=Loja.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+    equipe = serializers.PrimaryKeyRelatedField(
+        queryset=Equipe.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+    password = serializers.CharField(write_only=True, required=False)
+    pin = serializers.CharField(write_only=True, required=False, allow_blank=True, allow_null=True)
 
     class Meta:
         model = CustomUser
-        fields = ['id', 'username', 'first_name', 'last_name', 'email', 'cargo', 'loja', 'equipe']
+        fields = [
+            'id',
+            'username',
+            'first_name',
+            'last_name',
+            'email',
+            'cargo',
+            'loja',
+            'equipe',
+            'is_active',
+            'pin',
+            'password',
+        ]
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['loja'] = LojaSerializer(instance.loja).data if instance.loja else None
+        data['equipe'] = EquipeSerializer(instance.equipe).data if instance.equipe else None
+        return data
+
+    def validate_pin(self, value):
+        if value in (None, ''):
+            return None
+        if len(value) != 4 or not value.isdigit():
+            raise serializers.ValidationError('PIN deve ter exatamente 4 digitos numericos.')
+        return value
+
+    def validate(self, attrs):
+        cargo = attrs.get('cargo')
+        if self.instance:
+            cargo = cargo or self.instance.cargo
+
+        pin = attrs.get('pin')
+        if self.instance and pin is None:
+            pin = self.instance.pin
+
+        if cargo == 'VENDEDOR' and not pin:
+            raise serializers.ValidationError({'pin': 'PIN e obrigatorio para vendedores.'})
+
+        if not self.instance and not attrs.get('password'):
+            raise serializers.ValidationError({'password': 'Senha e obrigatoria.'})
+
+        return attrs
+
+    def create(self, validated_data):
+        password = validated_data.pop('password')
+        user = CustomUser(**validated_data)
+        user.set_password(password)
+        user.save()
+        return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop('password', None)
+        if password:
+            instance.set_password(password)
+
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        instance.save()
+        return instance

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -13,18 +13,8 @@ class EquipeSerializer(serializers.ModelSerializer):
         fields = ['id', 'nome']
 
 class UserSerializer(serializers.ModelSerializer):
-    loja = serializers.PrimaryKeyRelatedField(
-        queryset=Loja.objects.all(),
-        allow_null=True,
-        required=False,
-    )
-    equipe = serializers.PrimaryKeyRelatedField(
-        queryset=Equipe.objects.all(),
-        allow_null=True,
-        required=False,
-    )
-    password = serializers.CharField(write_only=True, required=False)
-    pin = serializers.CharField(write_only=True, required=False, allow_blank=True, allow_null=True)
+    loja = LojaSerializer(read_only=True)
+    equipe = EquipeSerializer(read_only=True)
 
     class Meta:
         model = CustomUser
@@ -38,54 +28,4 @@ class UserSerializer(serializers.ModelSerializer):
             'loja',
             'equipe',
             'is_active',
-            'pin',
-            'password',
         ]
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        data['loja'] = LojaSerializer(instance.loja).data if instance.loja else None
-        data['equipe'] = EquipeSerializer(instance.equipe).data if instance.equipe else None
-        return data
-
-    def validate_pin(self, value):
-        if value in (None, ''):
-            return None
-        if len(value) != 4 or not value.isdigit():
-            raise serializers.ValidationError('PIN deve ter exatamente 4 digitos numericos.')
-        return value
-
-    def validate(self, attrs):
-        cargo = attrs.get('cargo')
-        if self.instance:
-            cargo = cargo or self.instance.cargo
-
-        pin = attrs.get('pin')
-        if self.instance and pin is None:
-            pin = self.instance.pin
-
-        if cargo == 'VENDEDOR' and not pin:
-            raise serializers.ValidationError({'pin': 'PIN e obrigatorio para vendedores.'})
-
-        if not self.instance and not attrs.get('password'):
-            raise serializers.ValidationError({'password': 'Senha e obrigatoria.'})
-
-        return attrs
-
-    def create(self, validated_data):
-        password = validated_data.pop('password')
-        user = CustomUser(**validated_data)
-        user.set_password(password)
-        user.save()
-        return user
-
-    def update(self, instance, validated_data):
-        password = validated_data.pop('password', None)
-        if password:
-            instance.set_password(password)
-
-        for field, value in validated_data.items():
-            setattr(instance, field, value)
-
-        instance.save()
-        return instance

--- a/users/tests.py
+++ b/users/tests.py
@@ -60,6 +60,8 @@ class UserMeViewTests(APITestCase):
         self.assertEqual(response.data['first_name'], 'João')
         self.assertEqual(response.data['last_name'], 'Silva')
         self.assertEqual(response.data['cargo'], 'VENDEDOR')
+        self.assertNotIn('pin', response.data)
+        self.assertNotIn('password', response.data)
 
     def test_me_sem_token(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
## Resumo
- CRUD admin de usuarios com ativacao/desativacao via `is_active`, sem DELETE
- Validacao de PIN (4 digitos) obrigatoria para vendedores
- Rotas admin em `/api/admin/usuarios/` e testes automatizados

## Teste
```bash
docker exec -it joias_backend pytest tests.py