### PR TITLE
Feature: Invalidar Token de login

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -45,10 +45,18 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const logout = () => {
-    localStorage.removeItem("auth_token");
-    localStorage.removeItem("user");
-    setUser(null);
+  const logout = async () => {
+    try {
+      await api.post("/api/users/logout/");
+    } catch (error) {
+      console.error("Erro ao invalidar o token no backend:", error);
+    } finally {
+      // O bloco finally garante que, mesmo se a API der erro (ex: sem internet), 
+      // o usuário será deslogado localmente no frontend.
+      localStorage.removeItem("auth_token");
+      localStorage.removeItem("user");
+      setUser(null);
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/DashboardLayout.jsx
+++ b/frontend/src/pages/dashboard/DashboardLayout.jsx
@@ -23,9 +23,9 @@ const DashboardLayout = () => {
   const toggleMenu = () => setIsOpen(!isOpen);
   const closeMenu = () => setIsOpen(false);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     closeMenu();
-    logout();
+    await logout();
     navigate("/login");
   };
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -8,7 +8,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from .permissions import IsAdmin, IsSupervisorOrAdmin, IsVendedor, IsDispositivo
-from core.models import Loja
+
+import pytest
+from users.models import CustomUser
+from core.models import Loja, Equipe  # se necessário para criar usuário completo
 
 User = get_user_model()
 
@@ -317,3 +320,131 @@ class VendedorListViewTests(APITestCase):
         
         results = response.data.get('results', response.data) if isinstance(response.data, dict) else response.data
         self.assertEqual(len(results), 0)
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def user(db):
+    # Cria um usuário genérico (pode ser vendedor, admin, etc.)
+    return CustomUser.objects.create_user(
+        email='teste@example.com',
+        username='testeuser',
+        first_name='Teste',
+        last_name='Silva',
+        password='senha123',
+        cargo='VENDEDOR'
+    )
+
+@pytest.fixture
+def auth_token(user):
+    token, _ = Token.objects.get_or_create(user=user)
+    return token.key
+
+@pytest.fixture
+def authenticated_client(api_client, auth_token):
+    api_client.credentials(HTTP_AUTHORIZATION=f'Token {auth_token}')
+    return api_client
+
+
+# -------------------------------------------------------------
+# Teste 1: Logout com token válido
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_logout_com_token_valido(authenticated_client, user, auth_token):
+    url = reverse('logout')  # nome definido em users/urls.py como name='logout'
+    response = authenticated_client.post(url)
+
+    assert response.status_code == 200
+    assert response.json() == {"detail": "Logout realizado com sucesso."}
+    
+    # Verifica que o token foi deletado do banco
+    with pytest.raises(Token.DoesNotExist):
+        Token.objects.get(key=auth_token)
+
+
+# -------------------------------------------------------------
+# Teste 2: Acessar endpoint protegido após logout (token deletado)
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_token_inutilizado_apos_logout(authenticated_client, user, auth_token):
+    # Primeiro faz logout
+    logout_url = reverse('logout')
+    authenticated_client.post(logout_url)
+
+    # Tenta acessar um endpoint protegido qualquer (ex: /api/user/me/)
+    # Assumindo que o endpoint /api/user/me/ já existe (Issue #1)
+    # Se não existir, pode testar com qualquer endpoint que use IsAuthenticated.
+    # Vou usar o próprio logout (que exige autenticação) como referência.
+    response = authenticated_client.post(logout_url)  # token já foi deletado
+    
+    # O client ainda tem a credencial antiga, mas o token não existe mais
+    assert response.status_code == 401
+    # Ou, dependendo da implementação do DRF, pode ser 401 Unauthorized
+    # O JSON pode ser {"detail": "Invalid token."}
+
+
+# -------------------------------------------------------------
+# Teste 3: Requisição sem token
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_logout_sem_token(api_client):
+    url = reverse('logout')
+    response = api_client.post(url)
+    assert response.status_code == 401
+    # O DRF retorna {"detail": "Authentication credentials were not provided."}
+    assert 'detail' in response.json()
+
+
+# -------------------------------------------------------------
+# Teste 4: Token inválido ou já deletado
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_logout_com_token_invalido(api_client):
+    # Simula um token que não existe no banco
+    api_client.credentials(HTTP_AUTHORIZATION='Token token_inexistente123')
+    url = reverse('logout')
+    response = api_client.post(url)
+    assert response.status_code == 401
+    # O DRF retorna o erro traduzido {"detail": "Token inválido."}
+    assert response.json()['detail'] == 'Token inválido.'
+
+
+# -------------------------------------------------------------
+# Teste extra: Logout deve aceitar apenas método POST
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_logout_apenas_post(authenticated_client):
+    url = reverse('logout')
+    # GET não deve funcionar
+    response_get = authenticated_client.get(url)
+    assert response_get.status_code == 405  # Method Not Allowed
+    
+    # POST funciona (já testado acima)
+
+
+# -------------------------------------------------------------
+# Teste extra: Logout com usuário de cargo DISPOSITIVO também funciona
+# -------------------------------------------------------------
+@pytest.mark.django_db
+def test_logout_com_dispositivo(db):
+    dispositivo = CustomUser.objects.create_user(
+        email='tablet@loja.com',
+        username='tablet01',
+        first_name='Tablet',
+        last_name='Loja',
+        password='123456',
+        cargo='DISPOSITIVO'
+    )
+    token = Token.objects.create(user=dispositivo)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+    
+    url = reverse('logout')
+    response = client.post(url)
+    assert response.status_code == 200
+    
+    # Token deletado
+    assert not Token.objects.filter(key=token.key).exists()

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
-from .views import CustomLoginView, UserMeView, VendedorListView
+from .views import CustomLoginView, UserMeView, VendedorListView, LogoutView
 
 urlpatterns = [
     path('login/', CustomLoginView.as_view(), name='api_login'),
     path('user/me/', UserMeView.as_view(), name='user-me'),
     path('vendedores/', VendedorListView.as_view(), name='vendedor-list'),
+    path('logout/', LogoutView.as_view(), name='logout')
+
+
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -6,6 +6,8 @@ from rest_framework.views import APIView
 from rest_framework import generics
 from .models import CustomUser
 from .serializers import UserSerializer, UserUpdateSerializer, VendedorSerializer
+from rest_framework.authentication import TokenAuthentication
+from rest_framework import status
 
 class CustomLoginView(ObtainAuthToken):
     def post(self, request, *args, **kwargs):
@@ -89,3 +91,15 @@ class VendedorListView(generics.ListAPIView):
 
         # Se não for ADMIN e não tiver loja vinculada, não retorna nada por segurança
         return CustomUser.objects.none()
+
+class LogoutView(APIView):
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        # request.user é o usuário autenticado; request.auth é o objeto Token
+        token = request.auth
+        if token:
+            token.delete()
+            return Response({"detail": "Logout realizado com sucesso."}, status=status.HTTP_200_OK)
+        return Response({"detail": "Token inválido."}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Teste para saber se o Token está de fato sendo invalidado: 

Passo 1: Verificar se a requisição está sendo enviada (Aba Network)
Com a sua aplicação aberta no painel do Dashboard, aperte F12 (ou botão direito > Inspecionar) para abrir o DevTools.
Vá até a aba Network (ou Rede).
No filtro dessa aba, você pode clicar em Fetch/XHR para ver apenas as chamadas de API.
Na interface do seu sistema, clique no botão de Sair do Sistema.
O que deve acontecer: Você deve ver uma requisição do tipo POST para a rota logout/ aparecer na lista. Se você clicar nela, o Status deve ser 200 OK. Isso prova que o React avisou o Django para queimar aquele token.

Passo 2: Verificar a limpeza local (Aba Application)
Quando o usuário desloga, não basta o backend invalidar o token, o navegador precisa esquecer dele também.
No mesmo painel do DevTools (F12), vá até a aba Application (ou Aplicativo).
No menu lateral esquerdo, expanda a seção Local Storage (Armazenamento Local) e clique no link do seu localhost:5173.
Você verá chaves como auth_token e user.
Faça o login de novo (para os dados aparecerem) e depois clique em Sair do Sistema.
O que deve acontecer: No exato momento em que você clica em Sair, as chaves auth_token e user devem desaparecer dali. Isso prova que o frontend limpou a "memória".

Passo 3: O Teste de Fogo Definitivo (Usando o token antigo)
Para ter 100% de certeza de que o token foi destruído no banco de dados através da ação do frontend:
Faça login na sua aplicação web normalmente.
Abra o DevTools (F12), vá na aba Application > Local Storage.
Copie o valor que está dentro do auth_token. Salve em um bloco de notas.
Agora, na sua aplicação web, clique em Sair do Sistema.
Abra o seu Postman. Tente fazer uma requisição para uma rota protegida (como GET http://localhost:8000/api/users/user/me/) passando aquele token que você copiou no cabeçalho Authorization: Token SEU_TOKEN_COPIADO.
O que deve acontecer: O Postman deve retornar um erro 401 Unauthorized com a mensagem "Token inválido" (ou similar).
Se o Passo 3 der erro 401, significa que o seu ciclo está perfeito! O usuário clicou em sair no frontend, o frontend mandou o token pro backend, o backend deletou o token do banco, e o frontend apagou o token do navegador.